### PR TITLE
proposed fix for mcc wan send error, locally tested

### DIFF
--- a/common/utils/formatters.ts
+++ b/common/utils/formatters.ts
@@ -117,5 +117,5 @@ export function ensV3Url(name: string) {
 }
 
 export function hexToNumber(hex: string) {
-  return new BN(stripHexPrefix(hex)).toNumber();
+  return new BN(stripHexPrefix(hex), 16);
 }


### PR DESCRIPTION
Closes **Sending Wan in MCC Error** (Asana)

### Description

WAN sending failed with the error "Number can only safely store up to 53 bits", which was due to running JavaScript's toNumber() method on large hexadecimal numbers before using them to construct Big Number instances (bn.js)

### Changes

Removed toNumber() call in util/formatters **hexToNumber** method and supplied the correct parameter indicating hexadecimal (16)

### Steps to Test

Tested locally, tests must still be implemented
